### PR TITLE
Fixed problems with GetUnixTimestamp

### DIFF
--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -12,8 +12,11 @@ namespace ConsoleTest
                 string apikey = "";
                 string appid = "";
                 var client = IntercomClient.GetClient(appid, apikey);
+
                 //var user = client.Users.Get();
-                var newuser = client.Users.Post(new {email = "test@test.com"});
+                var newuser = client.Users.Post(new { email = "test@test.com" });
+
+                //client.Events.Post("test_event", DateTime.Now, "userid", new { });
             }
             catch (Exception ex)
             {

--- a/IntercomDotnet/Client.cs
+++ b/IntercomDotnet/Client.cs
@@ -15,9 +15,9 @@ namespace IntercomDotNet
         public string UserName { get; set; }
         public string Password { get; set; }
 
-        public double GetUnixTimestamp(DateTime inputTime)
+        public long GetUnixTimestamp(DateTime inputTime)
         {
-            return (inputTime - new DateTime(1970, 1, 1).ToUniversalTime()).TotalSeconds;
+            return (long)inputTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds;
         }
 
         public dynamic Execute(string resource, Method method, Action<RestRequest> decorator)


### PR DESCRIPTION
- Return `long` to truncate milliseconds from `inputTime`
- Make sure that `inputTime` is UTC by doing `ToUniversalTime()` on it (will not have any affect if it already is UTC)
- Do not do `ToUniversalTime()` on 1970. Unix time is defined as seconds since 1970. To get UTC unix time, take diff in seconds between UTC and 1970
- For example: `DateTime.UtcNow` is: `2015-07-29 09:04:40` (local time is `2015-07-29 11:04:40`)
  This is equivalent to 1438160680 (which according to http://www.onlineconversion.com/unix_time.htm is `2015-07-29 09:04:40`)
