### PR TITLE
Added Delete support for /users endpoint

### DIFF
--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -19,6 +19,9 @@ namespace ConsoleTest
                 //client.Events.Post("test_event", DateTime.Now, "userid", new { });
 
                 //client.Messages.Post("email", "Hello", "This is just a test message", "personal", "put admin id here", "put user_id here");
+
+                //client.Users.Delete("put id here");
+                //client.Users.DeleteWithUserId("put user_id here");
             }
             catch (Exception ex)
             {

--- a/IntercomDotnet/Resources/Users.cs
+++ b/IntercomDotnet/Resources/Users.cs
@@ -18,13 +18,30 @@ namespace IntercomDotNet.Resources
                 });
         }
 
-        public dynamic Delete(object hash)
+        /// <summary>
+        /// Delete a User using the id parameters
+        /// </summary>
+        /// <param name="id">The id defined by Intercom</param>
+        /// <returns></returns>
+        public dynamic Delete(string id)
+        {
+            return Client.Execute(BaseUrlWithId, Method.DELETE, request =>
+            {
+                request.AddUrlSegment("id", id);
+            });
+        }
+
+        /// <summary>
+        /// Delete a User using the user_id parameter
+        /// </summary>
+        /// <param name="userId">The user_id defined by you</param>
+        /// <returns></returns>
+        public dynamic DeleteWithUserId(string userId)
         {
             return Client.Execute(BaseUrl, Method.DELETE, request =>
-                {
-                    request.RequestFormat = DataFormat.Json;
-                    request.AddBody(hash);
-                });
+            {
+                request.AddParameter("user_id", userId);
+            });
         }
 
         [Obsolete("userId is a string in the Intercom API so please use the string-based overload going forward.")]


### PR DESCRIPTION
Deleting users requires a DELETE to the /users endpoint using parameters in the URL. The body is ignored.

I removed the non functioning delete method and added two new. One using the Intercom id, and one using the custom user_id.

Hope you like it :)
